### PR TITLE
Tooltips (mk1)

### DIFF
--- a/src/lib/styles/styles.css
+++ b/src/lib/styles/styles.css
@@ -10,3 +10,28 @@
 @-moz-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
 @-webkit-keyframes spin { 100% { -webkit-transform: rotate(360deg); } }
 @keyframes spin { 100% { -webkit-transform: rotate(360deg); transform:rotate(360deg); } }
+
+/* Katie's Atlas of Viral Adaption used as a starting point for tooltip styling
+https://github.com/blab/atlas-of-viral-adaptation/blob/9b942e3405e4683ff80ada9aa67ec1101a1c5322/index.html
+*/
+div.tooltip {    
+  position: fixed;
+  display: none;
+  padding: 12px 12px;
+  background: #f6f6f6;
+  border: 0.5px solid #888;
+  border-radius: 1px;
+  color: #333;
+  text-align: left;
+  font-size: 12px;
+  max-width: 320px;
+  padding: .2rem .4rem;
+  pointer-events: none;
+}
+.tooltip p {
+  margin: 0px 0px;
+}
+.tooltip p > b {
+  color: #888;
+  font-weight: 300;
+}

--- a/src/lib/utils/tooltip.js
+++ b/src/lib/utils/tooltip.js
@@ -1,0 +1,59 @@
+/**
+ * Originally sourced from https://observablehq.com/@clhenrick/tooltip-component
+ * and then used in a few of my own projects subsequent to this (with changes)
+ */
+export class Tooltip {
+  constructor(parentElement) {
+    if (!parentElement || !parentElement.size()) {
+      throw new Error("Requires a parent element in which to create the tooltip");
+    }
+    this._selection = parentElement
+      .append("div")
+      .classed("tooltip", true);
+  }
+
+  move(event) {
+    if (!event) return;
+    const margin = 0;
+    const { clientX: x, clientY: y } = event;
+    const { width, height } = this.selection.node().getBoundingClientRect();                                                                        
+    const left = this.clamp(
+      margin,
+      x - width / 2,
+      window.innerWidth - width - margin
+    );
+    const top =
+      window.innerHeight > y + margin + height
+        ? y + margin
+        : y - height - margin;
+    this.selection.style("top", `${top}px`).style("left", `${left}px`);
+  }
+
+  display(callback, ...args) {
+    if (!callback || typeof callback !== "function") {
+      throw new Error("ToolTip.display requires a callback function that returns an HTML string");
+    }
+    this.selection.style("display", "block").html(callback.apply(this, args));
+  }
+
+  hide() {
+    this.selection.style("display", "none").html("");
+  }
+
+  clamp(min, d, max) {
+    return Math.max(min, Math.min(max, d));
+  }
+
+  get selection() {
+    return this._selection;
+  }
+
+  set selection(sel) {
+    if (sel && sel.size()) {
+      this._selection = sel;
+    } else {
+      throw new Error("selection must be a non-empty selected element");
+    }
+  }
+}
+


### PR DESCRIPTION
This implements tooltips for frequencies graphs. They're useful as-is, which is why I'm pushing up this commit, but this is not the final version. They're quite hard to use at the moment (small capture area, lots of elements sit over the capture element and swallow events), and it would be better to have a tooltip whenever mousing over the graph area which showed _all_ the frequency values for the given date.

- [x] tested locally

Going to merge immediately and update forecasts-ncov. 