### PR TITLE
Parse model update date

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -28,10 +28,6 @@ The approach should be (I think):
 2. Either the `<Panels>` or `<Graph>` component extracts the points required for its visualisation from `modelData.rawData`. I'd lean towards doing this in `<Panels>`. What data to extract is based on `params.key` and `params.interval`. How we store data would be decided by `params.graphType`: `lines` imply a temporal array of points, `points` imply one value per variant, `stream` is similar to `lines` with an additional data conversion into a stack (`y0`, `y1`).
 
 
-## Forecasting date
-
-This is currently taken as the final date in the 'dates' array, but this should be explicitly defined by them model JSON.
-
 ## Pivot variant
 
 Currently we use last variant in the array, however this is soon to be explicitly provided in the model JSON.

--- a/src/dragAndDrop.js
+++ b/src/dragAndDrop.js
@@ -46,6 +46,11 @@ function App() {
   return (
     <div id="AppContainer">
       <h1>{`Forecasting-viz preview for '${modelData.name}'`}</h1>
+      {modelData?.modelData?.get('updated') &&
+        <div className="abstract">
+          {`Model updated ${modelData?.modelData?.get('updated')}`}
+        </div>
+      }
       <div id="mainPanelsContainer" >
         {modelData.sites.filter((site) => !site.endsWith("_forecast")).map((site) => {
           const preset = getPreset(site);

--- a/src/sarsCov2-testApp.js
+++ b/src/sarsCov2-testApp.js
@@ -82,7 +82,7 @@ function App() {
       <div id="mainPanelsContainer" >
 
         <h2>{`General line graph (preset: 'frequency')`}</h2>
-        <div className="abstract">{`Data comes from MLR model, objects matching {'freq', 'freq_forecast'} + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}</div>
+        <div className="abstract">{`Data comes from MLR model (updated: ${mlrData?.modelData?.get('updated')}), objects matching {'freq', 'freq_forecast'} + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}</div>
         {/*You can inject styles via a prop like `styles={{top: 40}}`*/}
         <PanelDisplay data={mlrData} locations={locations} params={{preset: "frequency"}}/>
 
@@ -117,7 +117,7 @@ function App() {
 
         <h2>{`Estimated effective reproduction number over time (Renewal Model)`}</h2>
         <div className="abstract">
-          {`Data comes from renewal model objects matching 'R' + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}
+          {`Data comes from renewal model (updated: ${renewalData?.modelData?.get('updated')}) matching 'R' + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}
         </div>
         <PanelDisplay data={renewalData} locations={locations} params={{preset: "R_t"}}/>
 


### PR DESCRIPTION
This serves two purposes: we expose it via modelData so that the calling app can display this information, and it's used for the nowcasting - forecasting crossover date.

Both pages in the test app are updated to surface this information.

This key was added to the (ncov) models via https://github.com/nextstrain/forecasts-ncov/pull/26
