### PR TITLE
Full width panels for lineage growth advantage

### DIFF
--- a/src/lib/components/Panels.js
+++ b/src/lib/components/Panels.js
@@ -78,6 +78,11 @@ const responsiveSizing = (params, modelData, dimensions, locationList) => {
     width = outerWidth - 20 // outer div allowing for some margin
   }
 
+  /* If growthAdvantage and lineages, always use full width */
+  if (params.preset==="growthAdvantage" && numVariants > 20) {
+    width = outerWidth - 20 // outer div allowing for some margin
+  }
+
   /* control the spacing around graphs via the margin of each graph
   We export these as individual keys so they can be easily overridden.
   The initial ones are generally ok. */


### PR DESCRIPTION
### Description of proposed changes

Growth advantage is only legible at full width for lineages analysis. The live site had toggled over to 4 locations for lineages, which triggered a 2x2 grid. This worked for lineage frequencies but really didn't work for lineage growth advantages.

This PR makes it so that growth advantage panels with >20 variants are always shown full width.

### Testing

I tested locally with the current output of `forecasts-ncov`.

- [ ] Checks pass
