### PR TITLE
Raw data points

### DIFF
--- a/src/lib/components/Graph.js
+++ b/src/lib/components/Graph.js
@@ -58,16 +58,6 @@ export const Graph = ({modelData, sizes, location, params, options}) => {
 }
 
 
-/**
- * The params will be equality checked to decide when to update the graph.
- * Because `displayTopVariants() !== displayTopVariants()`, we want to calculate
- * them up-front so that we use the same reference each time expandParams() is
- * called. This has implications for components providing their own functions -
- * they must be memoised.
- * Some (but not all) of this could be removed if we didn't use factories
- * to create our tooltips, but factories do have their advantages!
- * @private
- */
 const tooltipFrequency = displayTopVariants({fmt: d3.format(".1%")});
 const tooltipGeneric = displayTopVariants();
 const percentageFormat = d3.format(".0%");

--- a/src/lib/components/Legend.js
+++ b/src/lib/components/Legend.js
@@ -34,15 +34,20 @@ const LegendContainer = styled.div`
   }
 `;
 
-const useLegend = (d3Container, modelData, sizes, setLegendSwatchHovered) => {
+const useLegend = (d3Container, modelData, sizes, setLegendSwatchHovered, preset) => {
   useEffect(() => {
     /* legend entries are arranged via the parent container's flexbox settings */
+
+    let variants = modelData.get('variants')
+    if (preset==="growthAdvantage") {
+      variants = variants.filter((v) => v!==modelData.get('pivot'))
+    }
 
     const dom = d3.select(d3Container.current);
     dom.selectAll("*").remove();
 
     const containers = dom.selectAll("legendContainers")
-      .data(modelData.get('variants'))
+      .data(variants)
       .enter().append("div")
         .style("display", "flex")
         .style("align-items", "center") // legend swatches vertically centered with legend text
@@ -63,12 +68,12 @@ const useLegend = (d3Container, modelData, sizes, setLegendSwatchHovered) => {
     containers.append("span")
       .text((variant) => modelData.get('variantDisplayNames').get(variant) || variant)
 
-  }, [d3Container, sizes, modelData, setLegendSwatchHovered])
+  }, [d3Container, sizes, modelData, setLegendSwatchHovered, preset])
 }
 
-export const Legend = ({modelData, sizes, setLegendSwatchHovered}) => {
+export const Legend = ({modelData, sizes, setLegendSwatchHovered, preset}) => {
   const legendContainer = useRef(null);
-  useLegend(legendContainer, modelData, sizes, setLegendSwatchHovered); // renders the legend
+  useLegend(legendContainer, modelData, sizes, setLegendSwatchHovered, preset); // renders the legend
   return (
     <LegendContainer sizes={sizes} id="legend" ref={legendContainer}/>
   );

--- a/src/lib/components/Legend.js
+++ b/src/lib/components/Legend.js
@@ -34,7 +34,7 @@ const LegendContainer = styled.div`
   }
 `;
 
-const useLegend = (d3Container, modelData, sizes) => {
+const useLegend = (d3Container, modelData, sizes, setLegendSwatchHovered) => {
   useEffect(() => {
     /* legend entries are arranged via the parent container's flexbox settings */
 
@@ -46,7 +46,9 @@ const useLegend = (d3Container, modelData, sizes) => {
       .enter().append("div")
         .style("display", "flex")
         .style("align-items", "center") // legend swatches vertically centered with legend text
-
+        .on("mouseover", (_, variant) => setLegendSwatchHovered(variant))
+        .on("mouseout", () => setLegendSwatchHovered(undefined))
+  
     containers.append("svg")
       .style("flex-shrink", "0")
       .attr("width", sizes.legendRadius*2)
@@ -61,12 +63,12 @@ const useLegend = (d3Container, modelData, sizes) => {
     containers.append("span")
       .text((variant) => modelData.get('variantDisplayNames').get(variant) || variant)
 
-  }, [d3Container, sizes, modelData])
+  }, [d3Container, sizes, modelData, setLegendSwatchHovered])
 }
 
-export const Legend = ({modelData, sizes}) => {
+export const Legend = ({modelData, sizes, setLegendSwatchHovered}) => {
   const legendContainer = useRef(null);
-  useLegend(legendContainer, modelData, sizes); // renders the legend
+  useLegend(legendContainer, modelData, sizes, setLegendSwatchHovered); // renders the legend
   return (
     <LegendContainer sizes={sizes} id="legend" ref={legendContainer}/>
   );

--- a/src/lib/components/Panels.js
+++ b/src/lib/components/Panels.js
@@ -177,6 +177,7 @@ const Panel = ({
   const [logit, toggleLogit] = useState(false);
   const [showDailyRawFreq, toggleShowDailyRawFreq] = useState(false);
   const [showWeeklyRawFreq, toggleShowWeeklyRawFreq] = useState(false);
+  const [legendSwatchHovered, setLegendSwatchHovered] = useState(undefined);
 
   const [outerDivRef, _dimensions] = useElementSize()
   const dimensions = useDebounce(_dimensions, 500);
@@ -203,7 +204,7 @@ const Panel = ({
       </OptionsContainer>
 
       <Container>
-        <Legend modelData={modelData} sizes={sizes} />
+        <Legend modelData={modelData} sizes={sizes} setLegendSwatchHovered={(canShowDailyRawFreq || canShowWeeklyRawFreq) ? setLegendSwatchHovered : () => {}} />
         <PanelSectionContainer smallMultipleWidth={sizes.width}>
           {locationList
             .map((location) => (
@@ -212,7 +213,7 @@ const Panel = ({
                 sizes={sizes}
                 location={location}
                 params={params}
-                options={{logit, showDailyRawFreq, showWeeklyRawFreq}}
+                options={{logit, showDailyRawFreq, showWeeklyRawFreq, legendSwatchHovered}}
                 key={`${params.preset || params.key}_${location}`}
               />
             ))

--- a/src/lib/components/Panels.js
+++ b/src/lib/components/Panels.js
@@ -175,14 +175,16 @@ const Panel = ({
 }) => {
   const {modelData, error} = data;
   const [logit, toggleLogit] = useState(false);
-  const [showRawData, toggleShowRawData] = useState(false);
+  const [showDailyRawFreq, toggleShowDailyRawFreq] = useState(false);
+  const [showWeeklyRawFreq, toggleShowWeeklyRawFreq] = useState(false);
 
   const [outerDivRef, _dimensions] = useElementSize()
   const dimensions = useDebounce(_dimensions, 500);
   const  locationList = locations || modelData?.get('locations');
   const sizes = {...responsiveSizing(params, modelData, dimensions, locationList), ...(styles ? styles : {})};
   const canUseLogit = params.canUseLogit || params.preset==="frequency";
-  const canShowRawData = params.preset==='frequency' && modelData && modelData?.get('sites')?.has('raw_freq');
+  const canShowDailyRawFreq = params.preset==='frequency' && modelData && modelData?.get('sites')?.has('daily_raw_freq');
+  const canShowWeeklyRawFreq = params.preset==='frequency' && modelData && modelData?.get('sites')?.has('weekly_raw_freq');
 
   if (error) {
     return (<ErrorMessage error={error}/>);
@@ -196,7 +198,8 @@ const Panel = ({
     <div ref={outerDivRef}>
       <OptionsContainer>
         {canUseLogit && <Toggle label="Logit transform" checked={logit} sizes={sizes} onChange={() => toggleLogit(!logit)}/>}
-        {canShowRawData && <Toggle label="Show raw data" checked={showRawData} sizes={sizes} onChange={() => toggleShowRawData(!showRawData)}/>}
+        {canShowDailyRawFreq && <Toggle label="Daily raw data" checked={showDailyRawFreq} sizes={sizes} onChange={() => toggleShowDailyRawFreq(!showDailyRawFreq)}/>}
+        {canShowWeeklyRawFreq && <Toggle label="Weekly raw data" checked={showWeeklyRawFreq} sizes={sizes} onChange={() => toggleShowWeeklyRawFreq(!showWeeklyRawFreq)}/>}
       </OptionsContainer>
 
       <Container>
@@ -209,7 +212,7 @@ const Panel = ({
                 sizes={sizes}
                 location={location}
                 params={params}
-                options={{logit, showRawData}}
+                options={{logit, showDailyRawFreq, showWeeklyRawFreq}}
                 key={`${params.preset || params.key}_${location}`}
               />
             ))

--- a/src/lib/components/Panels.js
+++ b/src/lib/components/Panels.js
@@ -204,7 +204,7 @@ const Panel = ({
       </OptionsContainer>
 
       <Container>
-        <Legend modelData={modelData} sizes={sizes} setLegendSwatchHovered={(canShowDailyRawFreq || canShowWeeklyRawFreq) ? setLegendSwatchHovered : () => {}} />
+        <Legend modelData={modelData} sizes={sizes} setLegendSwatchHovered={setLegendSwatchHovered} />
         <PanelSectionContainer smallMultipleWidth={sizes.width}>
           {locationList
             .map((location) => (

--- a/src/lib/components/Panels.js
+++ b/src/lib/components/Panels.js
@@ -45,6 +45,13 @@ const PanelSectionContainer = styled.div`
   grid-template-columns: repeat(auto-fill, minmax(${props => props.smallMultipleWidth}px, 1fr));
 `;
 
+const OptionsContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  justify-content: flex-end;
+`
+
 /**
  * This function should handle all styling parameters related to sizing -- graph sizes,
  * legend sizes, text sizes etc. It is a work in progress. All styles defined here can be
@@ -168,13 +175,14 @@ const Panel = ({
 }) => {
   const {modelData, error} = data;
   const [logit, toggleLogit] = useState(false);
+  const [showRawData, toggleShowRawData] = useState(false);
 
   const [outerDivRef, _dimensions] = useElementSize()
   const dimensions = useDebounce(_dimensions, 500);
   const  locationList = locations || modelData?.get('locations');
   const sizes = {...responsiveSizing(params, modelData, dimensions, locationList), ...(styles ? styles : {})};
   const canUseLogit = params.canUseLogit || params.preset==="frequency";
-
+  const canShowRawData = params.preset==='frequency' && modelData && modelData?.get('sites')?.has('raw_freq');
 
   if (error) {
     return (<ErrorMessage error={error}/>);
@@ -186,7 +194,11 @@ const Panel = ({
 
   return (
     <div ref={outerDivRef}>
-      {canUseLogit && <Toggle label="Logit transform" checked={logit} sizes={sizes} onChange={() => toggleLogit(!logit)}/>}
+      <OptionsContainer>
+        {canUseLogit && <Toggle label="Logit transform" checked={logit} sizes={sizes} onChange={() => toggleLogit(!logit)}/>}
+        {canShowRawData && <Toggle label="Show raw data" checked={showRawData} sizes={sizes} onChange={() => toggleShowRawData(!showRawData)}/>}
+      </OptionsContainer>
+
       <Container>
         <Legend modelData={modelData} sizes={sizes} />
         <PanelSectionContainer smallMultipleWidth={sizes.width}>
@@ -197,7 +209,7 @@ const Panel = ({
                 sizes={sizes}
                 location={location}
                 params={params}
-                options={{logit}}
+                options={{logit, showRawData}}
                 key={`${params.preset || params.key}_${location}`}
               />
             ))

--- a/src/lib/components/Panels.js
+++ b/src/lib/components/Panels.js
@@ -204,7 +204,7 @@ const Panel = ({
       </OptionsContainer>
 
       <Container>
-        <Legend modelData={modelData} sizes={sizes} setLegendSwatchHovered={setLegendSwatchHovered} />
+        <Legend modelData={modelData} sizes={sizes} setLegendSwatchHovered={setLegendSwatchHovered} preset={params.preset}/>
         <PanelSectionContainer smallMultipleWidth={sizes.width}>
           {locationList
             .map((location) => (

--- a/src/lib/utils/d3Graph.js
+++ b/src/lib/utils/d3Graph.js
@@ -186,10 +186,11 @@ D3Graph.prototype.drawPoints = function() {
       .filter((pt) => !isNaN(pt.get(this.params.key)))
   }
   this.svg.append('g')
-    .selectAll("dot")
+    .selectAll(".dot")
     .data(this.points)
     .enter()
     .append("circle")
+      .attr("class", "dot")
       .attr("cx", (d) => this.x(d.get('variant')))
       .attr("cy", (d) => this.y(d.get(this.params.key)))
       .attr("r", 4)
@@ -202,14 +203,15 @@ D3Graph.prototype.drawPoints = function() {
       })
   if (this.params.interval) {
     this.svg.append('g')
-      .selectAll("HDI")
+      .selectAll(".hdi")
       .data(this.points)
       .enter()
       .append('path')
+        .attr('class', 'hdi')
         .attr("fill", "none")
         .attr("stroke", (d) => this.modelData.get('variantColors').get(d.get('variant')) ||  this.modelData.get('variantColors').get('other'))
         .attr("stroke-width", 3)
-        .attr("stroke-opacity", 1)
+        .style("stroke-opacity", 1)
         .attr("d", (d) => `M ${this.x(d.get('variant'))} ${this.y(d.get(this.params.interval[0]))} L ${this.x(d.get('variant'))} ${this.y(d.get(this.params.interval[1]))}`)
         .call((sel) => {
           if (typeof this.params.tooltipPt!=="function") return;
@@ -397,6 +399,18 @@ D3Graph.prototype.singleVariantFocus = function(legendSwatchHovered) {
         .style('opacity', 1)
         .attr("stroke-width", 3)
     }
+  } else if (this.params.graphType==='points') {
+    /* We don't modify circle opacities here as HPD lines with circles drawn over
+    them don't look nice if both opacities are <1 */
+    const value = (d, normalValue, focusValue, unfocusedValue) => {
+      if (legendSwatchHovered===undefined) return normalValue;
+      if (d.get('variant')===legendSwatchHovered) return focusValue;
+      return unfocusedValue;
+    }
+    this.svg.selectAll('.dot')
+      .attr('r', (d) => value(d, 4, 6, 3))
+    this.svg.selectAll('.hdi') /* empty selection if no interval data available */
+      .style("stroke-opacity", (d) => value(d, 1, 1, 0.4))
   }
 }
 

--- a/src/lib/utils/d3Graph.js
+++ b/src/lib/utils/d3Graph.js
@@ -12,6 +12,7 @@ export function D3Graph(d3Container, sizes, modelData, params, options) {
   this.modelData = modelData;
   this.params = params;
   this.sizes = sizes;
+  this.setRawFrequencyStyles();
 
   this.createScales(options);
   this.drawAxes();
@@ -272,17 +273,26 @@ D3Graph.prototype.updateScale = function(options) {
   });
 }
 
-const rawFrequencyStyles = {
+D3Graph.prototype.setRawFrequencyStyles = function(options) {
+  /* The current responsiveSizing (Panels.js) sets the graph width. Common widths are 260px (small panels)
+  or ~the available page width */
+  const small = this.sizes.width < 300;
+  this.rawFrequencyStyles = {
     daily:  {
-      r: 1.1, rFocus: 3,
-      opacity: 0.3, opacityFocus: 1,
+      r: small ? 1.1 : 2,
+      rFocus: small ? 2 : 3,
+      opacity: 0.3,
+      opacityFocus: 1,
       colorModifier: (color) => d3.color(color).darker(0.5).toString()
     },
     weekly: {
-      r: 1.6, rFocus: 4,
-      opacity: 0.3, opacityFocus: 1,
+      r: small ? 1.6 : 2.5,
+      rFocus: small ? 2 : 3,
+      opacity: 0.3,
+      opacityFocus: 1,
       colorModifier: (color) => d3.color(color).brighter(0.2).toString()
     },
+  }
 }
 
 /**
@@ -300,7 +310,7 @@ D3Graph.prototype.toggleDailyRawFreqPoints = function(options) {
       .filter((pt) => pt.has(key) && Number.isFinite(pt.get(key)))
 
     const variantColor = this.getVariantColor(variant);
-    const pointColor = rawFrequencyStyles.daily.colorModifier(variantColor)
+    const pointColor = this.rawFrequencyStyles.daily.colorModifier(variantColor)
 
     this.svg.selectAll(`.${cssSafeName(`variant_${variant}`)}`)
       .selectAll("dailyRawFreqPoints")
@@ -310,8 +320,8 @@ D3Graph.prototype.toggleDailyRawFreqPoints = function(options) {
         .attr("class", "dailyRawFreqPoints")
         .attr("cx", (d) => this.x(d.get('date')))
         .attr("cy", (d) => this.y(d.get(key) || false))
-        .attr("r", rawFrequencyStyles.daily.r)
-        .style("opacity", rawFrequencyStyles.daily.opacity)
+        .attr("r", this.rawFrequencyStyles.daily.r)
+        .style("opacity", this.rawFrequencyStyles.daily.opacity)
         .style("fill", pointColor)
   })
 }
@@ -331,7 +341,7 @@ D3Graph.prototype.toggleWeeklyRawFreqPoints = function(options) {
       .filter((pt) => pt.has(key) && Number.isFinite(pt.get(key)))
 
     const variantColor = this.getVariantColor(variant);
-    const pointColor = rawFrequencyStyles.weekly.colorModifier(variantColor)
+    const pointColor = this.rawFrequencyStyles.weekly.colorModifier(variantColor)
 
     this.svg.selectAll(`.${cssSafeName(`variant_${variant}`)}`)
       .selectAll("weeklyRawFreqPoints")
@@ -341,8 +351,8 @@ D3Graph.prototype.toggleWeeklyRawFreqPoints = function(options) {
         .attr("class", "weeklyRawFreqPoints")
         .attr("cx", (d) => this.x(d.get('date')))
         .attr("cy", (d) => this.y(d.get(key) || false))
-        .attr("r", rawFrequencyStyles.weekly.r)
-        .style("opacity", rawFrequencyStyles.weekly.opacity)
+        .attr("r", this.rawFrequencyStyles.weekly.r)
+        .style("opacity", this.rawFrequencyStyles.weekly.opacity)
         .style("fill", pointColor)
   })
 }
@@ -350,19 +360,19 @@ D3Graph.prototype.toggleWeeklyRawFreqPoints = function(options) {
 D3Graph.prototype.changeRawFreqPointsFocus = function(legendSwatchHovered) {
   if (legendSwatchHovered===undefined) {
     this.svg.selectAll('.dailyRawFreqPoints')
-      .attr("r", rawFrequencyStyles.daily.r)
-      .style("opacity", rawFrequencyStyles.daily.opacity)
+      .attr("r", this.rawFrequencyStyles.daily.r)
+      .style("opacity", this.rawFrequencyStyles.daily.opacity)
     this.svg.selectAll('.weeklyRawFreqPoints')
-      .attr("r", rawFrequencyStyles.weekly.r)
-      .style("opacity", rawFrequencyStyles.weekly.opacity)
+      .attr("r", this.rawFrequencyStyles.weekly.r)
+      .style("opacity", this.rawFrequencyStyles.weekly.opacity)
   } else {
     const s = this.svg.selectAll(`.${cssSafeName(`variant_${legendSwatchHovered}`)}`);
     s.selectAll('.dailyRawFreqPoints')
-      .attr("r", rawFrequencyStyles.daily.rFocus)
-      .style("opacity", rawFrequencyStyles.daily.opacityFocus)
+      .attr("r", this.rawFrequencyStyles.daily.rFocus)
+      .style("opacity", this.rawFrequencyStyles.daily.opacityFocus)
     s.selectAll('.weeklyRawFreqPoints')
-      .attr("r", rawFrequencyStyles.weekly.rFocus)
-      .style("opacity", rawFrequencyStyles.weekly.opacityFocus)
+      .attr("r", this.rawFrequencyStyles.weekly.rFocus)
+      .style("opacity", this.rawFrequencyStyles.weekly.opacityFocus)
   }
 }
 

--- a/src/lib/utils/d3Graph.js
+++ b/src/lib/utils/d3Graph.js
@@ -262,39 +262,75 @@ D3Graph.prototype.updateScale = function(options) {
       .transition().duration(TRANSITION_DURATION)
       .attr("d", this.area(temporalPoints))
 
-    g.selectAll('.rawDataPoints') // may be empty - that's ok!
+    g.selectAll('.dailyRawFreqPoints') // may be empty - that's ok!
       .transition().duration(TRANSITION_DURATION)
-      .attr("cy", (d) => this.y(d.get(`raw_${this.params.key}`) || false))
+      .attr("cy", (d) => this.y(d.get(`daily_raw_freq`) || false))
+
+    g.selectAll('.weeklyRawFreqPoints') // may be empty - that's ok!
+      .transition().duration(TRANSITION_DURATION)
+      .attr("cy", (d) => this.y(d.get(`weekly_raw_freq`) || false))
   });
 }
 
 /**
- * Prototype called when the "show raw data" toggle is changed.
+ * Prototype called when the "Daily raw data" toggle is changed
  */
-D3Graph.prototype.toggleRawDataPoints = function(options) {
+D3Graph.prototype.toggleDailyRawFreqPoints = function(options) {
   if (this.params.graphType !== "lines") throw new Error("Not yet implemented")
-  if (!options.showRawData) {
-    this.svg.selectAll('.rawDataPoints').remove("*")
+  if (!options.showDailyRawFreq) {
+    this.svg.selectAll('.dailyRawFreqPoints').remove("*")
     return;
   }
-  const key = `raw_${this.params.key}`
+  const key = `daily_raw_freq`
   this.modelData.get('points').get(this.params.location).forEach((variantPoint, variant) => {
     const temporalPoints = variantPoint.get('temporal')
       .filter((pt) => pt.has(key) && Number.isFinite(pt.get(key)))
 
-    const color = this.getVariantColor(variant);
+    const variantColor = this.getVariantColor(variant);
+    const pointColor = d3.color(variantColor).darker(0.5).toString();
 
     this.svg.selectAll(`.${cssSafeName(`variant_${variant}`)}`)
-      .selectAll("rawDataPoints")
+      .selectAll("dailyRawFreqPoints")
       .data(temporalPoints)
       .enter()
       .append("circle")
-        .attr("class", "rawDataPoints")
+        .attr("class", "dailyRawFreqPoints")
         .attr("cx", (d) => this.x(d.get('date')))
         .attr("cy", (d) => this.y(d.get(key) || false))
-        .attr("r", 1.5)
+        .attr("r", 1.1)
         .style("opacity", 0.3)
-        .style("fill", color)
+        .style("fill", pointColor)
+  })
+}
+
+/**
+ * Prototype called when the "7-day smoothed data" toggle is changed
+ */
+D3Graph.prototype.toggleWeeklyRawFreqPoints = function(options) {
+  if (this.params.graphType !== "lines") throw new Error("Not yet implemented")
+  if (!options.showWeeklyRawFreq) {
+    this.svg.selectAll('.weeklyRawFreqPoints').remove("*")
+    return;
+  }
+  const key = `weekly_raw_freq`
+  this.modelData.get('points').get(this.params.location).forEach((variantPoint, variant) => {
+    const temporalPoints = variantPoint.get('temporal')
+      .filter((pt) => pt.has(key) && Number.isFinite(pt.get(key)))
+
+    const variantColor = this.getVariantColor(variant);
+    const pointColor = d3.color(variantColor).brighter(0.2).toString();
+
+    this.svg.selectAll(`.${cssSafeName(`variant_${variant}`)}`)
+      .selectAll("weeklyRawFreqPoints")
+      .data(temporalPoints)
+      .enter()
+      .append("circle")
+        .attr("class", "weeklyRawFreqPoints")
+        .attr("cx", (d) => this.x(d.get('date')))
+        .attr("cy", (d) => this.y(d.get(key) || false))
+        .attr("r", 1.6)
+        .style("opacity", 0.3)
+        .style("fill", pointColor)
   })
 }
 

--- a/src/lib/utils/d3Graph.js
+++ b/src/lib/utils/d3Graph.js
@@ -357,22 +357,46 @@ D3Graph.prototype.toggleWeeklyRawFreqPoints = function(options) {
   })
 }
 
-D3Graph.prototype.changeRawFreqPointsFocus = function(legendSwatchHovered) {
-  if (legendSwatchHovered===undefined) {
+D3Graph.prototype.singleVariantFocus = function(legendSwatchHovered) {
+  /**
+   * Calls to this method ultimately come from mouseover/mouseout events. It is
+   * _not_ guaranteed that a browser will fire a mouseout event (the faster the
+   * mouse move the more likely it is to be missed). For that reason we always
+   * ~reset the visual state in this method before highlighting the variant; this
+   * helps the case where we move from legend A to legend B and the browser doesn't
+   * fire a mouseout when leaving A. It will not address the case where we move from
+   * legend B to outside the legend; to address this we'd have to listen to mousemove
+   * events and manually check positions which I think is unnecessary complexity
+   * for the current state of the project.
+   */
+  if (this.params.graphType==="lines") {
     this.svg.selectAll('.dailyRawFreqPoints')
       .attr("r", this.rawFrequencyStyles.daily.r)
       .style("opacity", this.rawFrequencyStyles.daily.opacity)
     this.svg.selectAll('.weeklyRawFreqPoints')
       .attr("r", this.rawFrequencyStyles.weekly.r)
       .style("opacity", this.rawFrequencyStyles.weekly.opacity)
-  } else {
-    const s = this.svg.selectAll(`.${cssSafeName(`variant_${legendSwatchHovered}`)}`);
-    s.selectAll('.dailyRawFreqPoints')
-      .attr("r", this.rawFrequencyStyles.daily.rFocus)
-      .style("opacity", this.rawFrequencyStyles.daily.opacityFocus)
-    s.selectAll('.weeklyRawFreqPoints')
-      .attr("r", this.rawFrequencyStyles.weekly.rFocus)
-      .style("opacity", this.rawFrequencyStyles.weekly.opacityFocus)
+    this.svg.selectAll('.area')
+      .style('opacity', legendSwatchHovered===undefined ? 0.2 : 0)
+    this.svg.selectAll('.line')
+      .style('opacity', legendSwatchHovered===undefined ? 0.8 : 0.3)
+      .attr("stroke-width", 2)
+    if (legendSwatchHovered!==undefined) {
+      const s = this.svg.selectAll(`.${cssSafeName(`variant_${legendSwatchHovered}`)}`);
+      s.selectAll('.dailyRawFreqPoints')
+        .attr("r", this.rawFrequencyStyles.daily.rFocus)
+        .style("opacity", this.rawFrequencyStyles.daily.opacityFocus)
+      s.selectAll('.weeklyRawFreqPoints')
+        .attr("r", this.rawFrequencyStyles.weekly.rFocus)
+        .style("opacity", this.rawFrequencyStyles.weekly.opacityFocus)
+      /* The HPD opacity has been set to 0 - re-enable for the focus variant */
+      s.selectAll('.area')
+        .style('opacity', 0.2)
+      /* The lines opacity has been lowered - increase for the focus variant */
+      s.selectAll('.line')
+        .style('opacity', 1)
+        .attr("stroke-width", 3)
+    }
   }
 }
 

--- a/src/lib/utils/d3Graph.js
+++ b/src/lib/utils/d3Graph.js
@@ -272,6 +272,19 @@ D3Graph.prototype.updateScale = function(options) {
   });
 }
 
+const rawFrequencyStyles = {
+    daily:  {
+      r: 1.1, rFocus: 3,
+      opacity: 0.3, opacityFocus: 1,
+      colorModifier: (color) => d3.color(color).darker(0.5).toString()
+    },
+    weekly: {
+      r: 1.6, rFocus: 4,
+      opacity: 0.3, opacityFocus: 1,
+      colorModifier: (color) => d3.color(color).brighter(0.2).toString()
+    },
+}
+
 /**
  * Prototype called when the "Daily raw data" toggle is changed
  */
@@ -287,7 +300,7 @@ D3Graph.prototype.toggleDailyRawFreqPoints = function(options) {
       .filter((pt) => pt.has(key) && Number.isFinite(pt.get(key)))
 
     const variantColor = this.getVariantColor(variant);
-    const pointColor = d3.color(variantColor).darker(0.5).toString();
+    const pointColor = rawFrequencyStyles.daily.colorModifier(variantColor)
 
     this.svg.selectAll(`.${cssSafeName(`variant_${variant}`)}`)
       .selectAll("dailyRawFreqPoints")
@@ -297,8 +310,8 @@ D3Graph.prototype.toggleDailyRawFreqPoints = function(options) {
         .attr("class", "dailyRawFreqPoints")
         .attr("cx", (d) => this.x(d.get('date')))
         .attr("cy", (d) => this.y(d.get(key) || false))
-        .attr("r", 1.1)
-        .style("opacity", 0.3)
+        .attr("r", rawFrequencyStyles.daily.r)
+        .style("opacity", rawFrequencyStyles.daily.opacity)
         .style("fill", pointColor)
   })
 }
@@ -318,7 +331,7 @@ D3Graph.prototype.toggleWeeklyRawFreqPoints = function(options) {
       .filter((pt) => pt.has(key) && Number.isFinite(pt.get(key)))
 
     const variantColor = this.getVariantColor(variant);
-    const pointColor = d3.color(variantColor).brighter(0.2).toString();
+    const pointColor = rawFrequencyStyles.weekly.colorModifier(variantColor)
 
     this.svg.selectAll(`.${cssSafeName(`variant_${variant}`)}`)
       .selectAll("weeklyRawFreqPoints")
@@ -328,10 +341,29 @@ D3Graph.prototype.toggleWeeklyRawFreqPoints = function(options) {
         .attr("class", "weeklyRawFreqPoints")
         .attr("cx", (d) => this.x(d.get('date')))
         .attr("cy", (d) => this.y(d.get(key) || false))
-        .attr("r", 1.6)
-        .style("opacity", 0.3)
+        .attr("r", rawFrequencyStyles.weekly.r)
+        .style("opacity", rawFrequencyStyles.weekly.opacity)
         .style("fill", pointColor)
   })
+}
+
+D3Graph.prototype.changeRawFreqPointsFocus = function(legendSwatchHovered) {
+  if (legendSwatchHovered===undefined) {
+    this.svg.selectAll('.dailyRawFreqPoints')
+      .attr("r", rawFrequencyStyles.daily.r)
+      .style("opacity", rawFrequencyStyles.daily.opacity)
+    this.svg.selectAll('.weeklyRawFreqPoints')
+      .attr("r", rawFrequencyStyles.weekly.r)
+      .style("opacity", rawFrequencyStyles.weekly.opacity)
+  } else {
+    const s = this.svg.selectAll(`.${cssSafeName(`variant_${legendSwatchHovered}`)}`);
+    s.selectAll('.dailyRawFreqPoints')
+      .attr("r", rawFrequencyStyles.daily.rFocus)
+      .style("opacity", rawFrequencyStyles.daily.opacityFocus)
+    s.selectAll('.weeklyRawFreqPoints')
+      .attr("r", rawFrequencyStyles.weekly.rFocus)
+      .style("opacity", rawFrequencyStyles.weekly.opacityFocus)
+  }
 }
 
 /**

--- a/src/lib/utils/parse.js
+++ b/src/lib/utils/parse.js
@@ -101,6 +101,7 @@ export const parseModelData = (modelName, modelJson, sites, configProvidedVarian
     ["nowcastFinalDate", nowcastFinalDate],
     ["points", undefined],
     ["domains", undefined],
+    ["sites", sites],
     // TODO: use the explicit pivot in the metadata instead of assuming the
     // pivot is the last variant in the array once it has been added to the evofr output
     ["pivot", modelJson.metadata.variants[modelJson.metadata.variants.length - 1]]
@@ -158,7 +159,11 @@ export const parseModelData = (modelName, modelJson, sites, configProvidedVarian
           store.set(`${key}_HDI_95_lower`, d.value);
         } else if (d.ps==="HDI_95_upper") {
           store.set(`${key}_HDI_95_upper`, d.value);
+        } else if (site.startsWith('raw_')) {
+          // raw frequency points do not have a 'ps' property
+          store.set(key, d.value);
         }
+
       }
     })
 

--- a/src/lib/utils/parse.js
+++ b/src/lib/utils/parse.js
@@ -159,7 +159,10 @@ export const parseModelData = (modelName, modelJson, sites, configProvidedVarian
           store.set(`${key}_HDI_95_lower`, d.value);
         } else if (d.ps==="HDI_95_upper") {
           store.set(`${key}_HDI_95_upper`, d.value);
-        } else if (site.startsWith('raw_')) {
+        } else if (site==='daily_raw_freq') {
+          // raw frequency points do not have a 'ps' property
+          store.set(key, d.value);
+        } else if (site==='weekly_raw_freq') {
           // raw frequency points do not have a 'ps' property
           store.set(key, d.value);
         }

--- a/src/lib/utils/useGraph.js
+++ b/src/lib/utils/useGraph.js
@@ -62,7 +62,7 @@ export const useGraph = (dom, sizes, modelData, params, options) => {
         graph.current.toggleWeeklyRawFreqPoints(options)
       }
       if (!isEqual(prevDeps.current.options.legendSwatchHovered, options.legendSwatchHovered)) {
-        graph.current.changeRawFreqPointsFocus(options.legendSwatchHovered)
+        graph.current.singleVariantFocus(options.legendSwatchHovered)
       }
       prevDeps.current.options = options;
     }

--- a/src/lib/utils/useGraph.js
+++ b/src/lib/utils/useGraph.js
@@ -51,7 +51,7 @@ export const useGraph = (dom, sizes, modelData, params, options) => {
      */
 
     if (!isEqual(prevDeps.current.options, options)) {
-      console.log("Updating graph as options have changed");
+
       if (!isEqual(prevDeps.current.options.logit, options.logit)) {
         graph.current.updateScale(options)
       }
@@ -60,6 +60,9 @@ export const useGraph = (dom, sizes, modelData, params, options) => {
       }
       if (!isEqual(prevDeps.current.options.showWeeklyRawFreq, options.showWeeklyRawFreq)) {
         graph.current.toggleWeeklyRawFreqPoints(options)
+      }
+      if (!isEqual(prevDeps.current.options.legendSwatchHovered, options.legendSwatchHovered)) {
+        graph.current.changeRawFreqPointsFocus(options.legendSwatchHovered)
       }
       prevDeps.current.options = options;
     }

--- a/src/lib/utils/useGraph.js
+++ b/src/lib/utils/useGraph.js
@@ -24,22 +24,25 @@ export const useGraph = (dom, sizes, modelData, params, options) => {
 
     /**
      * If any props change for which we don't have the d3 code to nicely update the graph
-     * we just recreate it. Because sizes & params are often re-created by parent components
+     * we just recreate it. Because sizes ~& params~ are often re-created by parent components
      * we use a deep equality check here to avoid unnecessary renders of the graph.
      * Note that this block runs in dev mode as the modelData changes as react unmounts and
      * remounts every component the first time, but in production this shouldn't run
      * at all with our current design.
      * The model data is compare by reference, however in our intended usage of `useModelData`
      * this reference shouldn't change.
+     * UPDATE: `params` is no longer equality checked as while the data is semantically not changed
+     * by any code, it is not technically not equal as the functions are recreated as the components rerun.
+     * We could get around this by using `isEqualWith` with a customizer which ignored functions.
      */
     const sizesEqual = isEqual(prevDeps.current.sizes, sizes);
-    const paramsEqual = isEqual(prevDeps.current.params, params);
+    // const paramsEqual = isEqual(prevDeps.current.params, params);
     const modelDataEqual = prevDeps.current.modelData === modelData;
-    if (!sizesEqual || !paramsEqual || !modelDataEqual) {
+    if (!sizesEqual || !modelDataEqual) {
       // NOTE: following logging is useful to debug why the hook is running
       // console.log(`Recreating graph because these props changed: ${sizesEqual ? '' : 'sizes'} ${paramsEqual ? '' : 'params'} ${modelDataEqual ? '' : 'modelData'}`);
       prevDeps.current.sizes = sizes;
-      prevDeps.current.params = params;
+      // prevDeps.current.params = params;
       prevDeps.current.modelData = modelData;
       graph.current = new D3Graph(dom, sizes, modelData, params, options);
       return;

--- a/src/lib/utils/useGraph.js
+++ b/src/lib/utils/useGraph.js
@@ -45,7 +45,7 @@ export const useGraph = (dom, sizes, modelData, params, options) => {
       return;
     }
     /**
-     * Changes in options (currently only the logit toggle) have an associated
+     * Changes in options (e.g. the logit toggle) have an associated
      * update function. In the future this could include hovering over a variant
      * in the legend & highlighting that (for example).
      */
@@ -54,6 +54,9 @@ export const useGraph = (dom, sizes, modelData, params, options) => {
       console.log("Updating graph as options have changed");
       if (!isEqual(prevDeps.current.options.logit, options.logit)) {
         graph.current.updateScale(options)
+      }
+      if (!isEqual(prevDeps.current.options.showRawData, options.showRawData)) {
+        graph.current.toggleRawDataPoints(options)
       }
       prevDeps.current.options = options;
     }

--- a/src/lib/utils/useGraph.js
+++ b/src/lib/utils/useGraph.js
@@ -55,8 +55,11 @@ export const useGraph = (dom, sizes, modelData, params, options) => {
       if (!isEqual(prevDeps.current.options.logit, options.logit)) {
         graph.current.updateScale(options)
       }
-      if (!isEqual(prevDeps.current.options.showRawData, options.showRawData)) {
-        graph.current.toggleRawDataPoints(options)
+      if (!isEqual(prevDeps.current.options.showDailyRawFreq, options.showDailyRawFreq)) {
+        graph.current.toggleDailyRawFreqPoints(options)
+      }
+      if (!isEqual(prevDeps.current.options.showWeeklyRawFreq, options.showWeeklyRawFreq)) {
+        graph.current.toggleWeeklyRawFreqPoints(options)
       }
       prevDeps.current.options = options;
     }

--- a/src/sarsCov2-testApp.js
+++ b/src/sarsCov2-testApp.js
@@ -12,6 +12,54 @@ let locations = undefined;
 following line to remove this filtering */
 // locations = ["Australia", "Canada", "Denmark", "France", "China", "USA"];
 
+function App() {
+  const [count, setCount] = useState(1);
+
+  return (
+    <div id="AppContainer">
+      <h1>
+        evofr visualisation library
+      </h1>
+
+      <div className="abstract">
+        This page is used to test and develop the React Components which visualise evofr modelling datasets.
+      </div>
+
+      <button onClick={() => {
+        console.log("*** Triggering <App> to re-render ***");
+        setCount(count+1);
+      }}>
+        {`Trigger <App> re-render. n=${count}`}
+      </button>
+
+      <div style={{paddingBottom: '20px'}}/>
+      <div id="mainPanelsContainer" >
+        <Tabs>
+          <TabList>
+            <Tab>Clades / MLR</Tab>
+            <Tab>Lineages / MLR</Tab>
+            <Tab>Clades / Renewal</Tab>
+          </TabList>
+          <TabPanel>
+            <CladesMLR/>
+          </TabPanel>
+          <TabPanel>
+            <LineagesMLR/>
+          </TabPanel>
+          <TabPanel>
+            <RenewalMLR/>
+          </TabPanel>
+        </Tabs>
+
+      </div>
+
+    </div>
+  );
+}
+
+export default App;
+
+
 const DEFAULT_ENDPOINT_PREFIX = "https://nextstrain-data.s3.amazonaws.com/files/workflows/forecasts-ncov";
 const baseConfiguration = {
   sites: undefined,
@@ -67,104 +115,73 @@ const config = {
 const incidenceLinesTooltip = displayTopVariants();
 const incidenceDomain = getDomainUsingKey('I_smooth_HDI_95_upper');
 
-function App() {
+
+function CladesMLR() {
   const cladesMlrData = useModelData(config.cladesMlr);
-  const cladesRenewalData = useModelData(config.cladesRenewal);
-  const lineagesMlrData = useModelData(config.lineagesMlr);
-
-  const [count, setCount] = useState(1);
-
   return (
-    <div id="AppContainer">
-      <h1>
-        evofr visualisation library
-      </h1>
+    <>
+      <h2>{`General line graph (preset: 'frequency')`}</h2>
+      <div className="abstract">{`Data comes from Clades/MLR model (updated: ${cladesMlrData?.modelData?.get('updated')}), objects matching {'freq', 'freq_forecast'} + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}</div>
+      {/*You can inject styles via a prop like `styles={{top: 40}}`*/}
+      <PanelDisplay data={cladesMlrData} locations={locations} params={{preset: "frequency"}}/>
 
-      <div className="abstract">
-        This page is used to test and develop the React Components which visualise evofr modelling datasets.
-      </div>
-
-      <button onClick={() => {
-        console.log("*** Triggering <App> to re-render ***");
-        setCount(count+1);
-      }}>
-        {`Trigger <App> re-render. n=${count}`}
-      </button>
-
-      <div style={{paddingBottom: '20px'}}/>
-
-      <div id="mainPanelsContainer" >
-
-        <Tabs>
-          <TabList>
-            <Tab>Clades / MLR</Tab>
-            <Tab>Lineages / MLR</Tab>
-            <Tab>Clades / Renewal</Tab>
-          </TabList>
-
-          {/* ----------------------------- CLADES / MLR ----------------------------- */}
-          <TabPanel>
-            <h2>{`General line graph (preset: 'frequency')`}</h2>
-            <div className="abstract">{`Data comes from Clades/MLR model (updated: ${cladesMlrData?.modelData?.get('updated')}), objects matching {'freq', 'freq_forecast'} + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}</div>
-            {/*You can inject styles via a prop like `styles={{top: 40}}`*/}
-            <PanelDisplay data={cladesMlrData} locations={locations} params={{preset: "frequency"}}/>
-
-            <h2>{`Growth Advantage (preset: 'growthAdvantage')`}</h2>
-            <div className="abstract">{`Data comes from MLR model, objects matching 'ga' + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}</div>
-            <PanelDisplay data={cladesMlrData} locations={locations} params={{preset: "growthAdvantage"}}/>
-          </TabPanel>
-
-          {/* ----------------------------- LINEAGES / MLR ----------------------------- */}
-          <TabPanel>
-            <h2>{`General line graph (preset: 'frequency')`}</h2>
-            <div className="abstract">{`Data comes from Lineages/MLR model (updated: ${cladesMlrData?.modelData?.get('updated')}), objects matching {'freq', 'freq_forecast'} + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}</div>
-            {/*You can inject styles via a prop like `styles={{top: 40}}`*/}
-            <PanelDisplay data={lineagesMlrData} locations={locations} params={{preset: "frequency"}}/>
-
-            <h2>{`Growth Advantage (preset: 'growthAdvantage')`}</h2>
-            <div className="abstract">{`Data comes from Lineages/MLR model, objects matching 'ga' + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}</div>
-            <PanelDisplay data={lineagesMlrData} locations={locations} params={{preset: "growthAdvantage"}}/>
-          </TabPanel>
-
-          {/* ----------------------------- RENEWAL / MLR ----------------------------- */}
-          <TabPanel>
-            <h2>{`Stream graph (preset: 'stackedIncidence')`}</h2>
-            <div className="abstract">
-              {`Custom styling to be 400px wide (default: 250px).
-              Data comes from Renewal model objects matching 'I_smooth' + 'median'`}
-            </div>
-            <PanelDisplay data={cladesRenewalData} locations={locations}
-              styles={{width: 400}}
-              params={{preset: "stackedIncidence"}}
-            /> 
-
-            <h2>{`Line graph using I_smooth`}</h2>
-            <div className="abstract">
-              {`An example of using the 'params' React prop in the calling app to completely define how the
-              graph looks -- we specify the graphType (lines), the data key (I_smooth),
-              the HPD interval keys, the yDomain and the tooltip function`}
-            </div>
-            <PanelDisplay data={cladesRenewalData} locations={locations} params={{
-              graphType: "lines",
-              key: 'I_smooth',
-              interval:  ['I_smooth_HDI_95_lower', 'I_smooth_HDI_95_upper'],
-              intervalOpacity: 0.3,
-              yDomain: incidenceDomain,
-              tooltipXY: incidenceLinesTooltip,
-            }}/>
-
-            <h2>{`Estimated effective reproduction number over time (Renewal Model)`}</h2>
-            <div className="abstract">
-              {`Data comes from renewal model (updated: ${cladesRenewalData?.modelData?.get('updated')}) matching 'R' + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}
-            </div>
-            <PanelDisplay data={cladesRenewalData} locations={locations} params={{preset: "R_t"}}/>
-          </TabPanel>
-        </Tabs>
-
-      </div>
-
-    </div>
-  );
+      <h2>{`Growth Advantage (preset: 'growthAdvantage')`}</h2>
+      <div className="abstract">{`Data comes from MLR model, objects matching 'ga' + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}</div>
+      <PanelDisplay data={cladesMlrData} locations={locations} params={{preset: "growthAdvantage"}}/>
+    </>
+  )
 }
 
-export default App;
+function LineagesMLR() {
+  const lineagesMlrData = useModelData(config.lineagesMlr);
+  return (
+    <>
+      <h2>{`General line graph (preset: 'frequency')`}</h2>
+      <div className="abstract">{`Data comes from Lineages/MLR model (updated: ${lineagesMlrData?.modelData?.get('updated')}), objects matching {'freq', 'freq_forecast'} + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}</div>
+      {/*You can inject styles via a prop like `styles={{top: 40}}`*/}
+      <PanelDisplay data={lineagesMlrData} locations={locations} params={{preset: "frequency"}}/>
+
+      <h2>{`Growth Advantage (preset: 'growthAdvantage')`}</h2>
+      <div className="abstract">{`Data comes from Lineages/MLR model, objects matching 'ga' + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}</div>
+      <PanelDisplay data={lineagesMlrData} locations={locations} params={{preset: "growthAdvantage"}}/>
+    </>
+  )
+}
+
+function RenewalMLR() {
+  const cladesRenewalData = useModelData(config.cladesRenewal);
+  return (
+    <>
+      <h2>{`Stream graph (preset: 'stackedIncidence')`}</h2>
+      <div className="abstract">
+        {`Custom styling to be 400px wide (default: 250px).
+        Data comes from Renewal model objects matching 'I_smooth' + 'median'`}
+      </div>
+      <PanelDisplay data={cladesRenewalData} locations={locations}
+        styles={{width: 400}}
+        params={{preset: "stackedIncidence"}}
+      /> 
+
+      <h2>{`Line graph using I_smooth`}</h2>
+      <div className="abstract">
+        {`An example of using the 'params' React prop in the calling app to completely define how the
+        graph looks -- we specify the graphType (lines), the data key (I_smooth),
+        the HPD interval keys, the yDomain and the tooltip function`}
+      </div>
+      <PanelDisplay data={cladesRenewalData} locations={locations} params={{
+        graphType: "lines",
+        key: 'I_smooth',
+        interval:  ['I_smooth_HDI_95_lower', 'I_smooth_HDI_95_upper'],
+        intervalOpacity: 0.3,
+        yDomain: incidenceDomain,
+        tooltipXY: incidenceLinesTooltip,
+      }}/>
+
+      <h2>{`Estimated effective reproduction number over time (Renewal Model)`}</h2>
+      <div className="abstract">
+        {`Data comes from renewal model (updated: ${cladesRenewalData?.modelData?.get('updated')}) matching 'R' + {'median', 'HDI_95_lower', 'HDI_95_upper'}`}
+      </div>
+      <PanelDisplay data={cladesRenewalData} locations={locations} params={{preset: "R_t"}}/>
+    </>
+  )
+}

--- a/src/sarsCov2-testApp.js
+++ b/src/sarsCov2-testApp.js
@@ -43,7 +43,7 @@ const config = {
   'cladesMlr': {
     modelName: "clades/MLR",
     modelUrl: process.env.REACT_APP_CLADES_MLR || `${DEFAULT_ENDPOINT_PREFIX}/gisaid/nextstrain_clades/global/mlr/latest_results.json`,
-    ...baseConfiguration
+    sites: undefined,
   },
   'cladesRenewal': {
     modelName: "clades/renewal",


### PR DESCRIPTION
Implements the ability to toggle on/off raw data points to allow a quick way to compare model outputs against the input frequencies. 

**todo**
- [x] parse raw data frequencies from JSON (data not currently exported in model JSONs)
- [x] only show toggle if JSON contains raw data points