### PR TITLE
Allow JSON-defined variant colors + display names

### DIFF
--- a/api.md
+++ b/api.md
@@ -167,10 +167,11 @@ visualisation component in the future. See NOTES.md for more.
 | dates | <code>Array</code> | sorted array of YYYY-MM-DD dates, guaranteed not to have any holes.                         These dates bridge both `modelJson.metadata.dates` and `modelJson.metadata.forecast_dates`. |
 | locations | <code>Array</code> | modelJson.metadata.location |
 | dateIdx | <code>Map</code> | lookup for date string -> idx in dates array |
-| variantColors | <code>Map</code> | provided via `DatasetConfig`. Default colors set if not provided. |
-| variantDisplayNames | <code>Map</code> | provided via `DatasetConfig`. Keys used if not provided. |
+| variantColors | <code>Map</code> | provided via `DatasetConfig`. Overrides data set in the JSON. Default colors set if not provided. |
+| variantDisplayNames | <code>Map</code> | provided via `DatasetConfig`. Overrides data set in the JSON. Keys used if not provided. |
 | pivot | <code>String</code> | Currently the final entry in the model's list of variants |
 | nowcastFinalDate | <code>string</code> |  |
+| updated | <code>string</code> |  |
 | domains | <code>Object</code> |  |
 
 <a name="module_@nextstrain/evofr-viz..ModelDataWrapper"></a>

--- a/src/sarsCov2-testApp.js
+++ b/src/sarsCov2-testApp.js
@@ -53,7 +53,8 @@ const config = {
   'lineagesMlr': {
     modelName: "lineages/MLR",
     modelUrl: process.env.REACT_APP_LINEAGES_MLR || `${DEFAULT_ENDPOINT_PREFIX}/gisaid/pango_lineages/global/mlr/latest_results.json`,
-    ...baseConfiguration
+    // don't add baseConfiguration as the JSON defines the colours and we don't want the config to override this
+    sites: undefined,
   },
 }
 


### PR DESCRIPTION
_I'll leave this unmerged until we've committed to the key names and structure that I've used here._

Given an existing JSON such as:
```json
"metadata": {
    "variants": ["A", "B", "C"]
}
```

This would add the ability to extend this with JSON-defined colours and/or display names:

```json
"metadata": {
    "variants": ["A", "B", "C"],
    "variantColors": [
        ["A", "#edf8b1"],
        ["B", "#7fcdbb"],
        ["C", "#2c7fb8"]
    ],
    "variantDisplayNames": [
        ["A", "clade A"],
        ["B", "clade B"],
        ["C", "clade C"],
    ]
}
```
