### PR TITLE
Update dependency pins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "rc-switch": ">=4",
         "react": ">=16",
         "react-dom": ">=16",
-        "styled-components": ">=5.3"
+        "styled-components": ">=5.3",
+        "usehooks-ts": "^2.9.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.20.7",
@@ -40,7 +41,6 @@
         "rollup-plugin-gzip": "^3.1.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "serve": "^14.2.0",
-        "usehooks-ts": "^2.9.1",
         "web-vitals": "^2.1.4"
       },
       "peerDependencies": {
@@ -50,7 +50,7 @@
         "react": ">=16",
         "react-dom": ">=16",
         "styled-components": ">=5.3",
-        "usehooks-ts": ">=2.9"
+        "usehooks-ts": "^2.9.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -21157,7 +21157,6 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
       "integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
-      "dev": true,
       "engines": {
         "node": ">=16.15.0",
         "npm": ">=8"
@@ -35689,7 +35688,6 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
       "integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
-      "dev": true,
       "requires": {}
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "rc-switch": ">=4",
     "react": ">=16",
     "react-dom": ">=16",
-    "styled-components": ">=5.3"
+    "styled-components": ">=5.3",
+    "usehooks-ts": "^2.9.1"
   },
   "peerDependencies": {
     "d3": ">=7",
@@ -62,7 +63,7 @@
     "react": ">=16",
     "react-dom": ">=16",
     "styled-components": ">=5.3",
-    "usehooks-ts": ">=2.9"
+    "usehooks-ts": "^2.9.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.20.7",
@@ -88,7 +89,6 @@
     "rollup-plugin-gzip": "^3.1.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "serve": "^14.2.0",
-    "usehooks-ts": "^2.9.1",
     "web-vitals": "^2.1.4"
   }
 }


### PR DESCRIPTION
Pins `usehooks-ts` more tightly as a new install would pick up v3 which has removed the `useElementSize` hook (see <https://usehooks-ts.com/migrate-to-v3>). We also make this a dependency (not just a devDependency) as it's used in the `<Panel>` component.

Will merge sans review