### PR TITLE
Add file picker and improve input json validation and error messages

### DIFF
--- a/src/dragAndDrop.js
+++ b/src/dragAndDrop.js
@@ -10,13 +10,28 @@ function App() {
   /* TODO - if we use this in production, there's a race condition if
   you try to fetch & drag-on a JSON at the ~same time */
   useListeners(setModelData, setErrorState);
+  const handleFileSelect = useFileSelect(setModelData, setErrorState);
 
   if (errorState) {
     /* Slightly different error handling than the expected usage */
     return (
       <div id="AppContainer">
         <h1>Error!</h1>
-        <div className="abstract">{errorState}</div>
+        <div className="abstract">
+          <pre style={{
+            whiteSpace: 'pre-wrap',
+            wordWrap: 'break-word',
+            backgroundColor: '#f5f5f5',
+            padding: '15px',
+            borderRadius: '5px',
+            fontSize: '14px',
+            lineHeight: '1.5',
+            maxHeight: '80vh',
+            overflow: 'auto'
+          }}>
+            {errorState}
+          </pre>
+        </div>
       </div>
     )
   }
@@ -36,6 +51,8 @@ function App() {
         <h1>Drag & drop a model JSON to visualise</h1>
         <div className="abstract">
           This is intended as a simple way to preview JSONs,
+          <p/>
+          Or <button onClick={handleFileSelect} style={{padding: '10px 20px', cursor: 'pointer'}}>Choose a file from Finder</button>
           <p/>
           Alternatively, if your dataset is available via a URL, you can load it by adding the
           URL query parameter <code>?dataset=https://...</code> to the URL and reloading the page.
@@ -93,16 +110,33 @@ function useListeners(setModelData, setErrorState) {
       const files = event.dataTransfer.files;
       if (files.length!==1) {
         setErrorState(`Only one JSON can be used at a time, not ${files.length}.`);
-        return 
+        return
       }
       try {
         const modelJson = await readFile(files[0])
         const fileName = files[0].name;
-        const modelData = parseModelData(fileName, modelJson, undefined, undefined, undefined);
+
+        // Validate JSON structure before parsing
+        const validationError = validateModelJson(modelJson);
+        if (validationError) {
+          setErrorState(validationError);
+          return;
+        }
+
+        let modelData;
+        try {
+          modelData = parseModelData(fileName, modelJson, undefined, undefined, undefined);
+        } catch (parseError) {
+          // Parsing failed - provide helpful context
+          console.error('Parse error:', parseError);
+          setErrorState(formatError(parseError, fileName));
+          return;
+        }
+
         modelData.sites = modelJson.metadata.sites;
         setModelData({modelData, sites: modelJson.metadata.sites, name: fileName, error: undefined});
       } catch (err) {
-        setErrorState(`Error during file reading / parsing: ${err.message}`)
+        setErrorState(formatSimpleError(err, 'Error during file reading / parsing'))
       }
     }, [setErrorState, setModelData]
   )
@@ -149,16 +183,199 @@ function useUrlDefinedDataset(setModelData, setErrorState) {
         return Promise.reject(null);
       })
       .then((response) => response.json())
-      .then((modelJson) => {      
-        const modelData = parseModelData(datasetUrl, modelJson, undefined, undefined, undefined);
+      .then((modelJson) => {
+        // Validate JSON structure before parsing
+        const validationError = validateModelJson(modelJson);
+        if (validationError) {
+          setErrorState(`Successfully fetched the file at ${datasetUrl}, but the JSON structure is invalid:\n\n${validationError}`);
+          return;
+        }
+
+        let modelData;
+        try {
+          modelData = parseModelData(datasetUrl, modelJson, undefined, undefined, undefined);
+        } catch (parseError) {
+          // Parsing failed - provide helpful context
+          setErrorState(formatError(parseError, datasetUrl));
+          return;
+        }
+
         modelData.sites = modelJson.metadata.sites;
         setModelData({modelData, sites: modelJson.metadata.sites, name: datasetUrl, error: undefined});
       }).catch((err) => {
-        setErrorState(`Successfully fetched the file at ${datasetUrl}, but there was an error when parsing the file contents: ${err.message}`)
+        if (err) {
+          setErrorState(formatSimpleError(err, `Successfully fetched the file at ${datasetUrl}, but there was an error when parsing the file contents`))
+        }
       })
     }, [setModelData, setErrorState]
   )
   return fetchProgress;
+}
+
+function useFileSelect(setModelData, setErrorState) {
+  const fileInputRef = React.useRef(null);
+
+  const handleFileChange = useCallback(
+    async (event) => {
+      setErrorState("");
+      const files = event.target.files;
+      if (files.length !== 1) {
+        setErrorState(`Only one JSON can be used at a time, not ${files.length}.`);
+        return;
+      }
+      try {
+        const modelJson = await readFile(files[0]);
+        const fileName = files[0].name;
+
+        // Validate JSON structure before parsing
+        const validationError = validateModelJson(modelJson);
+        if (validationError) {
+          setErrorState(validationError);
+          return;
+        }
+
+        let modelData;
+        try {
+          modelData = parseModelData(fileName, modelJson, undefined, undefined, undefined);
+        } catch (parseError) {
+          // Parsing failed - provide helpful context
+          console.error('Parse error:', parseError);
+          setErrorState(formatError(parseError, fileName));
+          return;
+        }
+
+        modelData.sites = modelJson.metadata.sites;
+        setModelData({modelData, sites: modelJson.metadata.sites, name: fileName, error: undefined});
+      } catch (err) {
+        setErrorState(`Error during file reading / parsing: ${err.message}\n\nStack trace:\n${err.stack}`);
+      }
+      // Reset the input so the same file can be selected again
+      event.target.value = '';
+    },
+    [setErrorState, setModelData]
+  );
+
+  useEffect(() => {
+    // Create a hidden file input element
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.accept = '.json,application/json';
+    fileInput.style.display = 'none';
+    fileInput.addEventListener('change', handleFileChange);
+    document.body.appendChild(fileInput);
+    fileInputRef.current = fileInput;
+
+    return () => {
+      fileInput.removeEventListener('change', handleFileChange);
+      document.body.removeChild(fileInput);
+    };
+  }, [handleFileChange]);
+
+  const triggerFileSelect = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  return triggerFileSelect;
+}
+
+/**
+ * Formats an error message for display
+ */
+function formatError(error, fileName) {
+  const lines = [];
+
+  lines.push("╔════════════════════════════════════════════════════════════════╗");
+  lines.push("║                     PARSING ERROR                              ║");
+  lines.push("╚════════════════════════════════════════════════════════════════╝");
+  lines.push("");
+  lines.push(`File: ${fileName}`);
+  lines.push("");
+  lines.push(error.message);
+  lines.push("");
+  lines.push("─────────────────────────────────────────────────────────────────");
+  lines.push("Stack trace:");
+  lines.push("─────────────────────────────────────────────────────────────────");
+  lines.push(error.stack);
+
+  return lines.join('\n');
+}
+
+/**
+ * Formats a simple error message for display
+ */
+function formatSimpleError(error, title) {
+  const lines = [];
+
+  lines.push("╔════════════════════════════════════════════════════════════════╗");
+  lines.push("║                         ERROR                                  ║");
+  lines.push("╚════════════════════════════════════════════════════════════════╝");
+  lines.push("");
+  lines.push(title);
+  lines.push("");
+  lines.push(error.message);
+  lines.push("");
+  lines.push("─────────────────────────────────────────────────────────────────");
+  lines.push("Stack trace:");
+  lines.push("─────────────────────────────────────────────────────────────────");
+  lines.push(error.stack);
+
+  return lines.join('\n');
+}
+
+/**
+ * Validates the structure of the model JSON before parsing
+ * Returns an error message string if validation fails, or null if valid
+ */
+function validateModelJson(modelJson) {
+  if (!modelJson || typeof modelJson !== 'object') {
+    return 'Invalid JSON: The file does not contain a valid JSON object.';
+  }
+
+  if (!modelJson.metadata) {
+    return 'Invalid JSON structure: Missing required "metadata" field at the top level.\n\nExpected structure:\n{\n  "metadata": {...},\n  "data": [...]\n}';
+  }
+
+  const metadata = modelJson.metadata;
+  const missingFields = [];
+
+  if (!Array.isArray(metadata.sites)) {
+    missingFields.push('"metadata.sites" (array)');
+  }
+  if (!Array.isArray(metadata.variants)) {
+    missingFields.push('"metadata.variants" (array)');
+  }
+  if (!metadata.location) {
+    missingFields.push('"metadata.location" (string or array)');
+  }
+  if (!Array.isArray(metadata.dates) && !Array.isArray(metadata.forecast_dates)) {
+    missingFields.push('"metadata.dates" or "metadata.forecast_dates" (at least one array)');
+  }
+
+  if (missingFields.length > 0) {
+    return `Invalid JSON structure: Missing required fields in metadata:\n  - ${missingFields.join('\n  - ')}\n\nYour JSON has these metadata fields: ${Object.keys(metadata).join(', ')}`;
+  }
+
+  if (!Array.isArray(modelJson.data)) {
+    return 'Invalid JSON structure: Missing or invalid "data" field (expected an array).\n\nExpected structure:\n{\n  "metadata": {...},\n  "data": [{...}, {...}, ...]\n}';
+  }
+
+  if (modelJson.data.length === 0) {
+    return 'Invalid JSON: The "data" array is empty. Please provide model data.';
+  }
+
+  // Check a few data points for required fields
+  const sampleDataPoint = modelJson.data[0];
+  const dataPointMissingFields = [];
+  if (!sampleDataPoint.site) dataPointMissingFields.push('site');
+  if (!sampleDataPoint.location) dataPointMissingFields.push('location');
+  if (!sampleDataPoint.variant) dataPointMissingFields.push('variant');
+  if (sampleDataPoint.value === undefined) dataPointMissingFields.push('value');
+
+  if (dataPointMissingFields.length > 0) {
+    return `Invalid data point structure: The first data point is missing required fields:\n  - ${dataPointMissingFields.join('\n  - ')}\n\nExpected data point structure:\n{\n  "site": "...",\n  "location": "...",\n  "variant": "...",\n  "value": ...,\n  ...\n}\n\nFirst data point has: ${Object.keys(sampleDataPoint).join(', ')}`;
+  }
+
+  return null; // Validation passed
 }
 
 // https://github.com/nextstrain/auspice.us/blob/fd5a7d4aff8101077d4ae9a4075139d71fc7af52/auspice_client_customisation/handleDroppedFiles.js

--- a/src/lib/utils/parse.js
+++ b/src/lib/utils/parse.js
@@ -132,6 +132,25 @@ export const parseModelData = (modelName, modelJson, sites, configProvidedVarian
     data.set('variantDisplayNames', genericVariantDisplayNames(data.get('variants')))
   }
 
+  // Validate that all variants have colors assigned
+  const variantColors = data.get('variantColors');
+  const missingColors = [];
+  for (const variant of data.get('variants')) {
+    const color = variantColors.get(variant);
+    if (!color) {
+      missingColors.push(variant);
+    }
+  }
+  if (missingColors.length > 0) {
+    const availableColors = Array.from(variantColors.keys());
+    throw new Error(
+      `Missing colors for ${missingColors.length} variant(s): ${missingColors.join(', ')}\n\n` +
+      `All variants must have colors defined in metadata.variantColors.\n` +
+      `Variants with colors: ${availableColors.join(', ')}\n` +
+      `Variants without colors: ${missingColors.join(', ')}`
+    );
+  }
+
   let ga_min=100, ga_max=0;
 
   const points = new Map(
@@ -149,12 +168,29 @@ export const parseModelData = (modelName, modelJson, sites, configProvidedVarian
   const pointEstimates = new Set(['ga']);
 
   modelJson.data
-    .forEach((d) => {
+    .forEach((d, idx) => {
       const site = d.site;
       if (sites.has(site)) {
+        // Check if location and variant exist in metadata
+        const locationMap = points.get(d.location);
+        if (!locationMap) {
+          console.error(`ERROR at data point ${idx}: Location "${d.location}" not found in metadata.location`);
+          console.error(`Available locations: ${Array.from(points.keys()).join(', ')}`);
+          console.error(`Problematic data point:`, d);
+          throw new Error(`Location "${d.location}" in data not found in metadata.location. Available locations: ${Array.from(points.keys()).join(', ')}`);
+        }
+
+        const variantPoint = locationMap.get(d.variant);
+        if (!variantPoint) {
+          console.error(`ERROR at data point ${idx}: Variant "${d.variant}" not found in metadata.variants`);
+          console.error(`Available variants: ${Array.from(locationMap.keys()).join(', ')}`);
+          console.error(`Problematic data point:`, d);
+          throw new Error(`Variant "${d.variant}" in data not found in metadata.variants. Available variants: ${Array.from(locationMap.keys()).join(', ')}`);
+        }
+
         const store = pointEstimates.has(site) ?
-          points.get(d.location).get(d.variant) :
-          points.get(d.location).get(d.variant).get('temporal')[dateIdx.get(d.date)];
+          variantPoint :
+          variantPoint.get('temporal')[dateIdx.get(d.date)];
 
         /* if it's not a point estimate enforce a date */
         if (!pointEstimates.has(site) && dateIdx.get(d.date) === undefined) return;

--- a/src/lib/utils/tooltipDisplay.js
+++ b/src/lib/utils/tooltipDisplay.js
@@ -8,7 +8,7 @@ export function displayTopVariants({n=5, fmt=d3.format(".1f")}={}) {
     let values = [];
     locationData.forEach((variantPoint, variant) => {
       const d = variantPoint.get('temporal')[xIdx];
-      if (d.get('date') && d.get(params.key)) {
+      if (d && d.get('date') && d.get(params.key)) {
         values.push([variant, d.get(params.key)])
       }
     });


### PR DESCRIPTION
Not cleaned up - I don't have the time to make a nice PR right now. Maybe @jameshadfield you can copy/paste what you'd be happy to use wherever you'd like to use it. For now we just use this branch locally with `npm run start` as it works well enough.

## Description of proposed changes

Grab bag of fixes/changes that @marie3003 and I used to help us debug the JSON produced by some MLR modelling code.

We got uninformative error messages that didn't make it obvious what the issue was, for example just this: `Error during file reading / parsing: Cannot read properties of undefined (reading 'get')`.

We got Claude to help us improve validation and error messages to make it faster to find issues in the JSON one uploads.

Now one gets nice console errors and stack traces:
<img width="899" height="165" alt="Google Chrome 2025-10-10 16 05 01" src="https://github.com/user-attachments/assets/104ce719-4eb8-4820-b656-55a31c845a08" />

We also ran into a (new?) macOS issue where you can't actually drag&drop from Finder, so we worked around that by adding a file picker.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
