### PR TITLE
Support user-defined point estimator functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,16 @@
+This is the changelog for forecasts-viz.
+All notable changes in a release will be documented in this file.
+
+This changelog is intended for _humans_ and follows many of the principles from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+Versions for this project follow the [Semantic Versioning rules](https://semver.org/spec/v2.0.0.html).
+Each heading below is a version released to downstream repositories (e.g., forecasts-ncov) and the date it was released.
+The "__NEXT__" heading below describes changes in the unreleased development source code and as such may not be routinely kept up to date.
+
+# __NEXT__
+
+# 0.2.0 (February 9, 2026)
+
+## Features
+
+ - Support user-defined point estimator functions for frequencies and growth advantages. See [#33](https://github.com/nextstrain/forecasts-viz/pull/33) for more.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextstrain/evofr-viz",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "React components for visualising evofr model JSONs",
   "private": true,
   "author": "Nextstrain",

--- a/src/lib/utils/parse.js
+++ b/src/lib/utils/parse.js
@@ -103,6 +103,8 @@ export const parseModelData = (modelName, modelJson, sites, configProvidedVarian
     variants.unshift(pivot);
   }
 
+  const ps_point_estimator = modelJson.metadata.ps_point_estimator || "median";
+
   const data = new Map([
     ["locations", modelJson.metadata.location],
     ["variants", variants],
@@ -162,7 +164,7 @@ export const parseModelData = (modelName, modelJson, sites, configProvidedVarian
         /* don't store forecasts under a different key, as they'll be plotted in the same graph */
         const key = site.replace("_forecast", "");
 
-        if (d.ps==="median") {
+        if (d.ps===ps_point_estimator) {
           store.set(key, d.value);
         } else if (d.ps==="HDI_95_lower") {
           store.set(`${key}_HDI_95_lower`, d.value);


### PR DESCRIPTION
## Description of proposed changes

Tries to load a user-defined point estimator function name from the model JSON's metadata. Use the "median" by default for backward compatibility. Note that when none of the data records match the requested function name, the display will be empty.

I tested this locally with a Vic model JSON using median first:

<img width="1183" height="265" alt="image" src="https://github.com/user-attachments/assets/b6b87f28-a442-431c-85da-d893c478e5ed" />

And then using the new "mean" values:

<img width="1175" height="258" alt="image 2" src="https://github.com/user-attachments/assets/cfe9e77f-747d-4658-8e3b-ec6afb68d4cc" />

As we expect, the differences are most noticeable at the most extreme forecast horizons and sparse data (e.g., C.5.7 in Southeast Asia).
<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

Required for https://github.com/nextstrain/forecasts-flu/issues/32

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
